### PR TITLE
correct imposm3 version number  like : 0.1dev-20151229-901b40b

### DIFF
--- a/docker-imposm3/Dockerfile
+++ b/docker-imposm3/Dockerfile
@@ -11,7 +11,7 @@ RUN ln -s /usr/lib/libgeos_c.so /usr/lib/libgeos.so
 WORKDIR $GOPATH
 RUN go get github.com/tools/godep
 RUN git clone https://github.com/omniscale/imposm3 src/github.com/omniscale/imposm3
-RUN cd src/github.com/omniscale/imposm3 && godep go install ./
+RUN cd src/github.com/omniscale/imposm3 && make update_version && godep go install ./
 
 ADD requirements.txt /home/requirements.txt
 RUN pip install -r /home/requirements.txt


### PR DESCRIPTION
I made a little improvement with imposm3 version number.

--- old
docker run -i -t dockerosm_imposm imposm3 version
0.1

--- new
docker run -i -t dockerosm_imposm imposm3 version
0.1dev-20151229-901b40b