### PR TITLE
remove restart command and healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,11 +22,10 @@ services:
     #  - "35432:5432"
     healthcheck:
         test: "exit 0"
-    restart: unless-stopped
 
   imposm:
     image: kartoza/docker-osm:imposm-latest
-    #build: docker-imposm3
+    build: docker-imposm3
     volumes:
       # These are sharable to other containers
       - ./settings:/home/settings
@@ -67,10 +66,9 @@ services:
       - QGIS_STYLE=yes
       # Use clip in the database
       - CLIP=no
-    restart: unless-stopped
 
   osmupdate:
-    #build: docker-osmupdate
+    build: docker-osmupdate
     image: kartoza/docker-osm:osmupdate-latest
     volumes:
       # These are sharable to other containers
@@ -78,6 +76,9 @@ services:
       - import_done:/home/import_done
       - import_queue:/home/import_queue
       - cache:/home/cache
+    depends_on:
+      db:
+        condition: service_healthy
     environment:
       # These are all currently the defaults but listed here for your
       # convenience if you want to change them
@@ -98,4 +99,3 @@ services:
       # seconds between 2 executions of the script
       # if 0, then no update will be done, only the first initial import from the PBF
       - TIME=120
-    restart: unless-stopped

--- a/docker-imposm3/importer.py
+++ b/docker-imposm3/importer.py
@@ -177,8 +177,7 @@ class Importer(object):
             self.info('No *.shp detected in %s, so no clipping.' % self.default['SETTINGS'])
 
         # In docker-compose, we should wait for the DB is ready.
-        self.info('The checkup is OK. The container will continue soon, after the database, in 45 seconds.')
-        sleep(45)
+        self.info('The checkup is OK.')
 
     def create_timestamp(self):
         """Create the timestamp with the undefined value until the real one."""

--- a/docker-osmupdate/download.py
+++ b/docker-osmupdate/download.py
@@ -89,8 +89,7 @@ class Downloader(object):
         else:
             self.info('OSM PBF file: ' + self.osm_file)
 
-        self.info('The checkup is OK. The container will continue soon, after the database, in 45 seconds.')
-        sleep(45)
+        self.info('The checkup is OK.')
 
     def _check_latest_timestamp(self):
         """Fetch the latest timestamp."""


### PR DESCRIPTION
@NyakudyaA I'm reverting some of your last PR:

* `test: "exit 0"` will always be true, so the healthcheck is loosing quite a lot of interest here
* if containers are quiting, it means that there is an error in the process. They are programmed to quit https://github.com/kartoza/docker-osm/blob/develop/docker-imposm3/importer.py#L71 so I propose to remove these `restart`

How does it look like for you? @timlinux as well