### PR TITLE
fix id missing in clip table and skipping importing shapefiles with g…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ import_clip:
 	@echo "------------------------------------------------------------------"
 	@echo "Importing clip shapefile into the database"
 	@echo "------------------------------------------------------------------"
-	@docker exec -t -i $(PROJECT_ID)_imposm /usr/bin/ogr2ogr -progress -skipfailures -lco GEOMETRY_NAME=geom -nlt PROMOTE_TO_MULTI -f PostgreSQL PG:"host=db user=docker password=docker dbname=gis" /home/settings/clip/clip.shp -sql "SELECT *, 1 as id from clip"
+	@docker exec -t -i $(PROJECT_ID)_imposm /usr/bin/ogr2ogr -progress -skipfailures -lco GEOMETRY_NAME=geom -nlt PROMOTE_TO_MULTI -f PostgreSQL PG:"host=db user=docker password=docker dbname=gis" /home/settings/clip/clip.shp
 
 remove_clip:
 	@echo

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ import_clip:
 	@echo "------------------------------------------------------------------"
 	@echo "Importing clip shapefile into the database"
 	@echo "------------------------------------------------------------------"
-	@docker exec -t -i $(PROJECT_ID)_imposm /usr/bin/ogr2ogr -lco GEOMETRY_NAME=geom -nlt PROMOTE_TO_MULTI -f PostgreSQL PG:"host=db user=docker password=docker dbname=gis" /home/settings/clip/clip.shp
+	@docker exec -t -i $(PROJECT_ID)_imposm /usr/bin/ogr2ogr -progress -skipfailures -lco GEOMETRY_NAME=geom -nlt PROMOTE_TO_MULTI -f PostgreSQL PG:"host=db user=docker password=docker dbname=gis" /home/settings/clip/clip.shp -sql "SELECT *, 1 as id from clip"
 
 remove_clip:
 	@echo

--- a/settings/clip/clip.sql
+++ b/settings/clip/clip.sql
@@ -11,8 +11,7 @@ BEGIN
         EXECUTE 'DELETE FROM ' || quote_ident(osm_table.table_name) || ' WHERE osm_id IN (
             SELECT DISTINCT osm_id
             FROM ' || quote_ident(osm_table.table_name) || '
-            LEFT JOIN clip ON ST_Intersects(geometry, geom)
-            WHERE clip.id IS NULL)
+            LEFT JOIN clip ON ST_Intersects(geometry, geom))
         ;';
     END LOOP;
 END;


### PR DESCRIPTION
# Problem

Currently clipping of tables in the database uses the id column which was fine considering that shp2pgsql automatically created one but now that we use ogr2ogr to import the shape file into the database the clip function still references the id column.

![screenshot 2018-10-09 at 11 26 15](https://user-images.githubusercontent.com/2510900/46662204-16676d80-cbbb-11e8-9e05-a90e4c5a8536.png)

# Solution
Add an ID column when importing the polygon boundary.
