### PR TITLE
Fix for updates-clipping issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,9 +89,10 @@ live_logs:
 import_clip:
 	@echo
 	@echo "------------------------------------------------------------------"
-	@echo "Importing clip shapefile into the database"
+	@echo "Importing clip shapefile and clip function into the database"
 	@echo "------------------------------------------------------------------"
 	@docker exec -t -i $(PROJECT_ID)_imposm /usr/bin/ogr2ogr -progress -skipfailures -lco GEOMETRY_NAME=geom -nlt PROMOTE_TO_MULTI -f PostgreSQL PG:"host=db user=docker password=docker dbname=gis" /home/settings/clip/clip.shp
+	@docker-compose -f $(COMPOSE_FILE) -p $(PROJECT_ID) exec imposm psql -h db -f /home/settings/clip/clip.sql gis docker
 
 remove_clip:
 	@echo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,7 @@ services:
     environment:
       - POSTGRES_USER=docker
       - POSTGRES_PASS=docker
+      - PGPASSWORD=docker
       - POSTGRES_DBNAME=gis
       - POSTGRES_PORT=5432
       - POSTGRES_HOST=db

--- a/settings/clip/clip.sql
+++ b/settings/clip/clip.sql
@@ -11,7 +11,8 @@ BEGIN
         EXECUTE 'DELETE FROM ' || quote_ident(osm_table.table_name) || ' WHERE osm_id IN (
             SELECT DISTINCT osm_id
             FROM ' || quote_ident(osm_table.table_name) || '
-            LEFT JOIN clip ON ST_Intersects(geometry, geom))
+            LEFT JOIN clip ON ST_Intersects(geometry, geom)
+            WHERE clip.ogc_fid IS NULL)
         ;';
     END LOOP;
 END;


### PR DESCRIPTION
This is a little fix for an issue I experienced while trying to perform clipping on updates:

- the clean_tables function is loaded into the db with the "make import_clip"
- the clean_tables function is adjusted so that it doesn't delete the whole tables