### PR TITLE
Fix postgres port not being considered in imposm3

### DIFF
--- a/docker-imposm3/importer.py
+++ b/docker-imposm3/importer.py
@@ -191,19 +191,21 @@ class Importer(object):
         """Test connection to PostGIS and create the URI."""
         try:
             connection = connect(
-                "dbname='%s' user='%s' host='%s' password='%s'" % (
+                "dbname='%s' user='%s' host='%s' port='%s' password='%s'" % (
                     self.default['POSTGRES_DBNAME'],
                     self.default['POSTGRES_USER'],
                     self.default['POSTGRES_HOST'],
+                    self.default['POSTGRES_PORT'],
                     self.default['POSTGRES_PASS']))
             self.cursor = connection.cursor()
         except OperationalError as e:
             self.error(e)
 
-        self.postgis_uri = 'postgis://%s:%s@%s/%s' % (
+        self.postgis_uri = 'postgis://%s:%s@%s:%s/%s' % (
             self.default['POSTGRES_USER'],
             self.default['POSTGRES_PASS'],
             self.default['POSTGRES_HOST'],
+            self.default['POSTGRES_PORT'],
             self.default['POSTGRES_DBNAME'])
 
     def import_custom_sql(self):
@@ -211,6 +213,7 @@ class Importer(object):
         self.info('Running the post import SQL file.')
         command = ['psql']
         command += ['-h', self.default['POSTGRES_HOST']]
+        command += ['-p', self.default['POSTGRES_PORT']]
         command += ['-U', self.default['POSTGRES_USER']]
         command += ['-d', self.default['POSTGRES_DBNAME']]
         command += ['-f', self.post_import_file]
@@ -221,6 +224,7 @@ class Importer(object):
         self.info('Installing QGIS styles.')
         command = ['psql']
         command += ['-h', self.default['POSTGRES_HOST']]
+        command += ['-p', self.default['POSTGRES_PORT']]
         command += ['-U', self.default['POSTGRES_USER']]
         command += ['-d', self.default['POSTGRES_DBNAME']]
         command += ['-f', self.qgis_style]


### PR DESCRIPTION
This fixes https://github.com/kartoza/docker-osm/issues/47

The POSTGRES_PORT parameter is allowed in the imposm3 dockerfile, but not used in establishing the connection. This PR fixes that by adding the port where appropriate.