### PR TITLE
fix(importer.py): replace mknod by Path.touch

### DIFF
--- a/docker-imposm3/importer.py
+++ b/docker-imposm3/importer.py
@@ -20,7 +20,8 @@
 """
 
 from sys import exit, stderr
-from os import environ, listdir, mknod
+from os import environ, listdir
+from pathlib import Path
 from shutil import move
 from os.path import join, exists, abspath, isabs
 from psycopg2 import connect, OperationalError
@@ -240,7 +241,7 @@ class Importer(object):
     def lockfile(self):
         setup_lockfile = join(self.default['SETTINGS'], 'importer.lock')
         if not exists(setup_lockfile):
-            mknod(setup_lockfile)
+            Path(setup_lockfile).touch()
 
     def run(self):
         """First checker."""


### PR DESCRIPTION
When I tested docker-osm I encountered an error with importer.py, more precisely with mknod function here:
https://github.com/kartoza/docker-osm/blob/develop/docker-imposm3/importer.py#L239
At runtime I got an exception telling me that mknod was not available.

I don't understand why this exception occured. I saw mknod was specific to Unix systems. I didn't investigate much on this. I fixed this by replacing mknod by pathlib.Path.touch.