### PR TITLE
Fix enrich error on latest library version

### DIFF
--- a/docker-osmenrich/enrich.py
+++ b/docker-osmenrich/enrich.py
@@ -19,8 +19,8 @@
  ***************************************************************************/
 """
 
-import sys
 import gzip
+import sys
 from os import environ, listdir, mkdir
 from os.path import join, exists, getsize
 from sys import exit, stderr
@@ -31,8 +31,6 @@ import xmltodict
 import yaml
 from dateutil import parser
 from psycopg2 import connect, OperationalError, ProgrammingError
-from xmltodict import OrderedDict
-
 
 class Enrich(object):
     mapping_type = {
@@ -174,7 +172,7 @@ class Enrich(object):
         """
         self.info('Load Mapping file data.')
         document = open(self.mapping_file, 'r')
-        mapping_data = yaml.load(document)
+        mapping_data = yaml.safe_load(document)
         try:
             for table, value in mapping_data['tables'].items():
                 try:
@@ -565,7 +563,7 @@ class Enrich(object):
                             modify_list = raw_content['osmChange']['modify']
                             for list in modify_list:
                                 for key, value in list.items():
-                                    if type(value) != OrderedDict:
+                                    if type(value) != dict:
                                         for osm_data in value:
                                             self.enrich_database_from_osm_data(
                                                 osm_data, key

--- a/docker-osmenrich/requirements.txt
+++ b/docker-osmenrich/requirements.txt
@@ -1,4 +1,4 @@
-psycopg2-binary
-python-dateutil
-pyyaml
-xmltodict
+psycopg2-binary==2.9.4
+python-dateutil==2.8.2
+PyYAML==6.0
+xmltodict==0.13.0


### PR DESCRIPTION
Hi @NyakudyaA 
Please check this PR

It will fix error on enrich for latest version of library

Also there are PR that related to this (the solution are same)
https://github.com/kartoza/docker-osm/pull/127
https://github.com/kartoza/docker-osm/pull/124